### PR TITLE
Add Claude 4.5 Sonnet support and update default model

### DIFF
--- a/computer-use-demo/README.md
+++ b/computer-use-demo/README.md
@@ -1,7 +1,7 @@
 # Anthropic Computer Use Demo
 
 > [!NOTE]
-> Now featuring support for the new Claude 4 models! The latest Claude 4 Sonnet (claude-sonnet-4-20250514) is now the default model, with Claude 4 Opus (claude-opus-4-20250514) also available. These models bring next-generation capabilities with the updated str_replace_based_edit_tool that replaces the previous str_replace_editor tool. The undo_edit command has been removed in this latest version for a more streamlined experience.
+> Now featuring support for the new Claude 4 models! The latest Claude 4.5 Sonnet (claude-sonnet-4-5-20250929) is now the default model, with Claude 4 Sonnet (claude-sonnet-4-20250514) and Claude 4 Opus (claude-opus-4-20250514) also available. These models bring next-generation capabilities with the updated str_replace_based_edit_tool that replaces the previous str_replace_editor tool. The undo_edit command has been removed in this latest version for a more streamlined experience.
 
 > [!CAUTION]
 > Computer use is a beta feature. Please be aware that computer use poses unique risks that are distinct from standard API features or chat interfaces. These risks are heightened when using computer use to interact with the internet. To minimize risks, consider taking precautions such as:

--- a/computer-use-demo/computer_use_demo/streamlit.py
+++ b/computer-use-demo/computer_use_demo/streamlit.py
@@ -32,7 +32,7 @@ from computer_use_demo.loop import (
 from computer_use_demo.tools import ToolResult, ToolVersion
 
 PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
-    APIProvider.ANTHROPIC: "claude-sonnet-4-20250514",
+    APIProvider.ANTHROPIC: "claude-sonnet-4-5-20250929",
     APIProvider.BEDROCK: "anthropic.claude-3-5-sonnet-20241022-v2:0",
     APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
 }
@@ -66,10 +66,18 @@ CLAUDE_4 = ModelConfig(
     has_thinking=True,
 )
 
+CLAUDE_4_5 = ModelConfig(
+    tool_version="computer_use_20250124",
+    max_output_tokens=128_000,
+    default_output_tokens=1024 * 16,
+    has_thinking=True,
+)
+
 MODEL_TO_MODEL_CONF: dict[str, ModelConfig] = {
     "claude-3-7-sonnet-20250219": SONNET_3_7,
     "claude-opus-4@20250508": CLAUDE_4,
     "claude-sonnet-4-20250514": CLAUDE_4,
+    "claude-sonnet-4-5-20250929": CLAUDE_4_5,
     "claude-opus-4-20250514": CLAUDE_4,
 }
 
@@ -513,10 +521,10 @@ def _render_message(
                 thinking_content = message.get("thinking", "")
                 st.markdown(f"[Thinking]\n\n{thinking_content}")
             elif message["type"] == "tool_use":
-                st.code(f'Tool Use: {message["name"]}\nInput: {message["input"]}')
+                st.code(f"Tool Use: {message['name']}\nInput: {message['input']}")
             else:
                 # only expected return types are text and tool_use
-                raise Exception(f'Unexpected response type {message["type"]}')
+                raise Exception(f"Unexpected response type {message['type']}")
         else:
             st.markdown(message)
 

--- a/computer-use-demo/computer_use_demo/tools/__init__.py
+++ b/computer-use-demo/computer_use_demo/tools/__init__.py
@@ -2,7 +2,7 @@ from .base import CLIResult, ToolResult
 from .bash import BashTool20241022, BashTool20250124
 from .collection import ToolCollection
 from .computer import ComputerTool20241022, ComputerTool20250124
-from .edit import EditTool20241022, EditTool20250124, EditTool20250429
+from .edit import EditTool20241022, EditTool20250124, EditTool20250429, EditTool20250728
 from .groups import TOOL_GROUPS_BY_VERSION, ToolVersion
 
 __ALL__ = [
@@ -14,6 +14,7 @@ __ALL__ = [
     EditTool20241022,
     EditTool20250124,
     EditTool20250429,
+    EditTool20250728,
     ToolCollection,
     ToolResult,
     ToolVersion,

--- a/computer-use-demo/computer_use_demo/tools/edit.py
+++ b/computer-use-demo/computer_use_demo/tools/edit.py
@@ -557,5 +557,10 @@ class EditTool20250429(BaseAnthropicTool):
         )
 
 
+class EditTool20250728(EditTool20250124):
+    api_type: Literal["text_editor_20250728"] = "text_editor_20250728"  # pyright: ignore[reportIncompatibleVariableOverride]
+    name: Literal["str_replace_based_edit_tool"] = "str_replace_based_edit_tool"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
 class EditTool20241022(EditTool20250124):
     api_type: Literal["text_editor_20250429"] = "text_editor_20250429"  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/computer-use-demo/computer_use_demo/tools/groups.py
+++ b/computer-use-demo/computer_use_demo/tools/groups.py
@@ -4,7 +4,7 @@ from typing import Literal
 from .base import BaseAnthropicTool
 from .bash import BashTool20241022, BashTool20250124
 from .computer import ComputerTool20241022, ComputerTool20250124
-from .edit import EditTool20241022, EditTool20250124, EditTool20250429, EditTool20250728
+from .edit import EditTool20241022, EditTool20250429, EditTool20250728
 
 ToolVersion = Literal[
     "computer_use_20250124", "computer_use_20241022", "computer_use_20250429"

--- a/computer-use-demo/computer_use_demo/tools/groups.py
+++ b/computer-use-demo/computer_use_demo/tools/groups.py
@@ -4,7 +4,7 @@ from typing import Literal
 from .base import BaseAnthropicTool
 from .bash import BashTool20241022, BashTool20250124
 from .computer import ComputerTool20241022, ComputerTool20250124
-from .edit import EditTool20241022, EditTool20250124, EditTool20250429
+from .edit import EditTool20241022, EditTool20250124, EditTool20250429, EditTool20250728
 
 ToolVersion = Literal[
     "computer_use_20250124", "computer_use_20241022", "computer_use_20250429"
@@ -29,7 +29,7 @@ TOOL_GROUPS: list[ToolGroup] = [
     ),
     ToolGroup(
         version="computer_use_20250124",
-        tools=[ComputerTool20250124, EditTool20250124, BashTool20250124],
+        tools=[ComputerTool20250124, EditTool20250728, BashTool20250124],
         beta_flag="computer-use-2025-01-24",
     ),
     ToolGroup(


### PR DESCRIPTION
## Summary
- Add support for Claude 4.5 Sonnet (claude-sonnet-4-5-20250929) with new EditTool20250728 compatibility
- Update default model from Claude 4 Sonnet to Claude 4.5 Sonnet
- Update README to reflect the new default model
- Add CLAUDE_4_5 model configuration with appropriate tool version

## Changes
- Added EditTool20250728 class for claude-sonnet-4-5-20250929 compatibility
- Updated PROVIDER_TO_DEFAULT_MODEL_NAME to use claude-sonnet-4-5-20250929
- Updated tool groups to use EditTool20250728 for computer_use_20250124 version
- Updated README note section to mention Claude 4.5 Sonnet as default

## Test plan
- [ ] Verify Claude 4.5 Sonnet works with computer use demo
- [ ] Confirm tool compatibility with new model
- [ ] Test that existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)